### PR TITLE
Revert "Cache `dist` dir to allow for incremental builds (#3)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   directories:
     - $HOME/.ghc
     - $HOME/.cabal
-    - dist
 
 matrix:
   include:


### PR DESCRIPTION
This reverts commit c6be08f97d3fdd1f765238bd3811b93b964960c7 as the
caching of the `dist` directory does not seem to allow travis to cache
the build files. This is probably due to the fact that every file is out
of date as the repository is freshly cloned every build.
