### PR TITLE
Make InnerStorage its own data structure

### DIFF
--- a/src/Polar/Storage.hs
+++ b/src/Polar/Storage.hs
@@ -38,12 +38,12 @@ class Monad m => StorePolar m where
     retrieveVec  :: TypeRep -> m (V.Vector Dynamic)
 
 instance StorePolar Core where
-    storeDyn dyn        = storage . at (dynTypeRep dyn) . non' _Empty . innerDyns %%=
+    storeDyn dyn        = storage . at (dynTypeRep dyn) . non' _Empty . dyns %%=
         \v -> (V.length v, v `V.snoc` dyn)
-    retrieveDyn rep idx = preuse (storage . at rep . non' _Empty . innerDyns . ix idx)
-    storeName dyn k idx = storage . at (dynTypeRep dyn) . non' _Empty . innerNames . at k ?= idx
-    retrieveName rep k  = use (storage . at rep . non' _Empty . innerNames . at k)
-    retrieveVec rep     = use (storage . at rep . non' _Empty . innerDyns)
+    retrieveDyn rep idx = preuse (storage . at rep . non' _Empty . dyns . ix idx)
+    storeName dyn k idx = storage . at (dynTypeRep dyn) . non' _Empty . names . at k ?= idx
+    retrieveName rep k  = use (storage . at rep . non' _Empty . names . at k)
+    retrieveVec rep     = use (storage . at rep . non' _Empty . dyns)
 
 -- store functions
 

--- a/src/Polar/Types/Lenses.hs
+++ b/src/Polar/Types/Lenses.hs
@@ -6,6 +6,8 @@
 
 module Polar.Types.Lenses where
 
+import Control.Lens (nearly)
+import Control.Lens.Empty
 import Control.Lens.TH (makeFields)
 import Polar.Types.Point
 import Polar.Types.Box
@@ -13,6 +15,7 @@ import Polar.Types.Core
 import Polar.Types.Sys
 import Polar.Types.Logic
 import Polar.Types.Engine
+import Polar.Types.Storage
 
 makeFields ''Point
 makeFields ''Box
@@ -21,3 +24,7 @@ makeFields ''SysState
 makeFields ''System
 makeFields ''LogicState
 makeFields ''Engine
+makeFields ''InnerStorage
+
+instance AsEmpty InnerStorage where
+    _Empty = nearly defaultInnerStorage innerStorageNull

--- a/src/Polar/Types/Storage.hs
+++ b/src/Polar/Types/Storage.hs
@@ -16,15 +16,20 @@ import Data.Typeable
 import Data.Dynamic
 import qualified Data.Vector as V
 import qualified Data.HashMap.Lazy as M
-import Control.Lens (Lens, Field1, Field2, _1, _2)
 
-type InnerStorage = (V.Vector Dynamic, M.HashMap String Int)
+data InnerStorage = InnerStorage
+    { _innerStorageDyns  :: V.Vector Dynamic
+    , _innerStorageNames :: M.HashMap String Int
+    }
 
-innerDyns :: Field1 s t a b => Lens s t a b
-innerDyns = _1
+defaultInnerStorage :: InnerStorage
+defaultInnerStorage = InnerStorage
+    { _innerStorageDyns  = V.empty
+    , _innerStorageNames = M.empty
+    }
 
-innerNames :: Field2 s t a b => Lens s t a b
-innerNames = _2
+innerStorageNull :: InnerStorage -> Bool
+innerStorageNull s = V.null (_innerStorageDyns s)
 
 type Storage = M.HashMap TypeRep InnerStorage
 


### PR DESCRIPTION
Previously InnerStorage was a type alias to a tuple as tuples of size 2
already have an instance of AsEmpty. This patch implements an instance
for the new InnerStorage type through the `nearly` function, using
`defaultInnerStorage` as the empty value and `innerStorageNull` as the
null condition.
