### PR TITLE
Storage: Lookup by any key type

### DIFF
--- a/polar-engine.cabal
+++ b/polar-engine.cabal
@@ -38,7 +38,7 @@ library
                        Polar.Types.Storage,
                        Polar.Types.Lenses
   build-depends:       base >=4.8 && <5.0, containers >=0.5.5, transformers >=0.4, mtl >=2.2, bytestring >=0.10, lens >=4.12,
-                       hint >=0.4, unordered-containers >=0.2, vector >=0.11,
+                       hint >=0.4, unordered-containers >=0.2, vector >=0.11, hashable >=1.2,
                        OpenGL >=2.12, OpenGLRaw >2.1, GLFW-b >=1.4.7,
                        tight-apply >=0.1 && <0.2, truthful >=0.1 && <0.2,
                        polar-shader >=0.1 && <0.2, polar-configfile >=0.5

--- a/src/Polar/Storage.hs
+++ b/src/Polar/Storage.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleInstances #-}
 
@@ -15,14 +16,15 @@
 
 module Polar.Storage
 ( Proxy(..)
-, store, storeNamed
-, mRetrieveP, mRetrieveNamedP, retrieveP, retrieveNamedP, retrieveAllP
-, mRetrieve, mRetrieveNamed, retrieve, retrieveNamed, retrieveAll
+, store, storeKeyed
+, mRetrieveP, mRetrieveKeyedP, retrieveP, retrieveKeyedP, retrieveAllP
+, mRetrieve,  mRetrieveKeyed,  retrieve,  retrieveKeyed,  retrieveAll
 ) where
 
 import Data.Maybe (maybeToList)
 import Data.Typeable
 import Data.Dynamic
+import Data.Hashable (Hashable, hash)
 import qualified Data.Vector as V
 import Control.Monad.Trans (MonadIO)
 import Polar.Types
@@ -33,27 +35,40 @@ import Polar.Log
 class Monad m => StorePolar m where
     storeDyn     :: Dynamic -> m Int
     retrieveDyn  :: TypeRep -> Int -> m (Maybe Dynamic)
-    storeName    :: Dynamic -> String -> Int -> m ()
-    retrieveName :: TypeRep -> String -> m (Maybe Int)
+    storeName    :: (Typeable k, Hashable k) => Dynamic -> k -> Int -> m ()
+    retrieveName :: (Typeable k, Hashable k) => TypeRep -> k -> m (Maybe Int)
     retrieveVec  :: TypeRep -> m (V.Vector Dynamic)
 
 instance StorePolar Core where
-    storeDyn dyn        = storage . at (dynTypeRep dyn) . non' _Empty . dyns %%=
+    storeDyn dyn = storage.at (dynTypeRep dyn).non' _Empty.dyns %%=
         \v -> (V.length v, v `V.snoc` dyn)
-    retrieveDyn rep idx = preuse (storage . at rep . non' _Empty . dyns . ix idx)
-    storeName dyn k idx = storage . at (dynTypeRep dyn) . non' _Empty . names . at k ?= idx
-    retrieveName rep k  = use (storage . at rep . non' _Empty . names . at k)
-    retrieveVec rep     = use (storage . at rep . non' _Empty . dyns)
+
+    retrieveDyn rep idx = preuse (storage.at rep.non' _Empty.dyns.ix idx)
+
+    storeName :: forall k. (Typeable k, Hashable k) => Dynamic -> k -> Int -> Core ()
+    storeName dyn key idx = storage . at (dynTypeRep dyn) . non' _Empty
+                          . keys    . at (typeRep p)      . non' _Empty
+                          . at (hash key) ?= idx
+      where p = Proxy :: Proxy k
+
+    retrieveName :: forall k. (Typeable k, Hashable k) => TypeRep -> k -> Core (Maybe Int)
+    retrieveName rep key = use $ storage . at rep         . non' _Empty
+                               . keys    . at (typeRep p) . non' _Empty
+                               . at (hash key)
+      where p = Proxy :: Proxy k
+
+    retrieveVec rep = use (storage.at rep.non' _Empty.dyns)
 
 -- store functions
 
 store :: (StorePolar m, Typeable a) => a -> m Int
 store x = storeDyn (toDyn x)
 
-storeNamed :: (StorePolar m, Typeable a) => a -> String -> m Int
-storeNamed x k = do
+storeKeyed :: (StorePolar m, Typeable a, Typeable k, Hashable k)
+           => a -> k -> m Int
+storeKeyed x key = do
     i <- store x
-    storeName (toDyn x) k i
+    storeName (toDyn x) key i
     pure i
 
 -- explicit proxy functions
@@ -61,16 +76,18 @@ storeNamed x k = do
 mRetrieveP :: (StorePolar m, Typeable a) => Proxy a -> Int -> m (Maybe a)
 mRetrieveP proxy idx = maybe Nothing fromDynamic <$> retrieveDyn (typeRep proxy) idx
 
-mRetrieveNamedP :: (StorePolar m, Typeable a) => Proxy a -> String -> m (Maybe a)
-mRetrieveNamedP proxy k = maybe (pure Nothing) (mRetrieveP proxy) =<< retrieveName (typeRep proxy) k
+mRetrieveKeyedP :: (StorePolar m, Typeable a, Typeable k, Hashable k)
+                => Proxy a -> k -> m (Maybe a)
+mRetrieveKeyedP proxy key = maybe (pure Nothing) (mRetrieveP proxy) =<< retrieveName (typeRep proxy) key
 
 retrieveP :: (MonadIO m, StorePolar m, Typeable a) => Proxy a -> Int -> m a
 retrieveP proxy idx = maybe (logFatal msg) pure =<< mRetrieveP proxy idx
   where msg = "Failed to retrieve value from storage (TypeRep = " ++ show (typeRep proxy) ++ ", Index = " ++ show idx ++ ")"
 
-retrieveNamedP :: (MonadIO m, StorePolar m, Typeable a) => Proxy a -> String -> m a
-retrieveNamedP proxy k = maybe (logFatal msg) (retrieveP proxy) =<< retrieveName (typeRep proxy) k
-  where msg = "Failed to retrieve value from storage (TypeRep = " ++ show (typeRep proxy) ++ ", Key = " ++ k ++ ")"
+retrieveKeyedP :: (MonadIO m, StorePolar m, Typeable a, Typeable k, Hashable k)
+               => Proxy a -> k -> m a
+retrieveKeyedP proxy key = maybe (logFatal msg) (retrieveP proxy) =<< retrieveName (typeRep proxy) key
+  where msg = "Failed to retrieve value from storage (TypeRep = " ++ show (typeRep proxy) ++ ", Key = " ++ show (hash key) ++ ")"
 
 retrieveAllP :: (StorePolar m, Typeable a) => Proxy a -> m [a]
 retrieveAllP proxy = foldMap maybeToList . fmap fromDynamic <$> retrieveVec (typeRep proxy)
@@ -80,14 +97,16 @@ retrieveAllP proxy = foldMap maybeToList . fmap fromDynamic <$> retrieveVec (typ
 mRetrieve :: (StorePolar m, Typeable a) => Int -> m (Maybe a)
 mRetrieve = mRetrieveP Proxy
 
-mRetrieveNamed :: (StorePolar m, Typeable a) => String -> m (Maybe a)
-mRetrieveNamed = mRetrieveNamedP Proxy
+mRetrieveKeyed :: (StorePolar m, Typeable a, Typeable k, Hashable k)
+               => k -> m (Maybe a)
+mRetrieveKeyed = mRetrieveKeyedP Proxy
 
 retrieve :: (MonadIO m, StorePolar m, Typeable a) => Int -> m a
 retrieve = retrieveP Proxy
 
-retrieveNamed :: (MonadIO m, StorePolar m, Typeable a) => String -> m a
-retrieveNamed = retrieveNamedP Proxy
+retrieveKeyed :: (MonadIO m, StorePolar m, Typeable a, Typeable k, Hashable k)
+              => k -> m a
+retrieveKeyed = retrieveKeyedP Proxy
 
 retrieveAll :: (StorePolar m, Typeable a) => m [a]
 retrieveAll = retrieveAllP Proxy

--- a/src/Polar/Storage.hs
+++ b/src/Polar/Storage.hs
@@ -38,12 +38,12 @@ class Monad m => StorePolar m where
     retrieveVec  :: TypeRep -> m (V.Vector Dynamic)
 
 instance StorePolar Core where
-    storeDyn dyn        = storage . at (dynTypeRep dyn) . non' _Empty . innerDyns %%=
+    storeDyn dyn        = storage . at (dynTypeRep dyn) . non' _Empty . dyns %%=
         \v -> (V.length v, v `V.snoc` dyn)
-    retrieveDyn rep idx = preuse (storage . at rep . non' _Empty . innerDyns . ix idx)
-    storeName dyn k idx = storage . at (dynTypeRep dyn) . non' _Empty . innerNames . at k ?= idx
-    retrieveName rep k  = use (storage . at rep . non' _Empty . innerNames . at k)
-    retrieveVec rep     = use (storage . at rep . non' _Empty . innerDyns)
+    retrieveDyn rep idx = preuse (storage . at rep . non' _Empty . dyns . ix idx)
+    storeName dyn k idx = storage . at (dynTypeRep dyn) . non' _Empty . names . at k ?= idx
+    retrieveName rep k  = use (storage . at rep . non' _Empty . names . at k)
+    retrieveVec rep     = use (storage . at rep . non' _Empty . dyns)
 
 -- store functions
 

--- a/src/Polar/System/Renderer/OpenGL_3_2.hs
+++ b/src/Polar/System/Renderer/OpenGL_3_2.hs
@@ -50,7 +50,7 @@ startupF = do
         Nothing  -> logFatal "Failed to create window"
         Just win -> do
             logWrite DEBUG "Created window"
-            storeNamed win "window"
+            storeKeyed win "window"
             liftIO $ GLFW.makeContextCurrent (Just win)
             gl (GL.clearColor $= GL.Color4 0.02 0.05 0.1 0)
             program <- createProgram "main.shader"
@@ -109,7 +109,7 @@ createDrawable vertices = do
 
 tickF :: Core ()
 tickF = do
-    win <- retrieveNamed "window"
+    win <- retrieveKeyed "window"
     bool (render win) exit =<< liftIO (GLFW.windowShouldClose win)
 
 render :: GLFW.Window -> Core ()
@@ -126,7 +126,7 @@ renderOne (vao, n) = do
 
 shutdownF :: Core ()
 shutdownF = do
-    liftIO . GLFW.destroyWindow =<< retrieveNamed "window"
+    liftIO . GLFW.destroyWindow =<< retrieveKeyed "window"
     logWrite DEBUG "Destroyed window"
     liftIO GLFW.terminate
 

--- a/src/Polar/Types/Lenses.hs
+++ b/src/Polar/Types/Lenses.hs
@@ -6,6 +6,8 @@
 
 module Polar.Types.Lenses where
 
+import Control.Lens (nearly)
+import Control.Lens.Empty
 import Control.Lens.TH (makeFields)
 import Polar.Types.Point
 import Polar.Types.Box
@@ -13,6 +15,7 @@ import Polar.Types.Core
 import Polar.Types.Sys
 import Polar.Types.Logic
 import Polar.Types.Engine
+import Polar.Types.Storage
 
 makeFields ''Point
 makeFields ''Box
@@ -21,3 +24,7 @@ makeFields ''SysState
 makeFields ''System
 makeFields ''LogicState
 makeFields ''Engine
+makeFields ''InnerStorage
+
+instance AsEmpty InnerStorage where
+    _Empty = nearly defaultInnerStorage innerStorageNull

--- a/src/Polar/Types/Lenses.hs
+++ b/src/Polar/Types/Lenses.hs
@@ -24,7 +24,7 @@ makeFields ''SysState
 makeFields ''System
 makeFields ''LogicState
 makeFields ''Engine
-makeFields ''InnerStorage
+makeFields ''VectorStorage
 
-instance AsEmpty InnerStorage where
-    _Empty = nearly defaultInnerStorage innerStorageNull
+instance AsEmpty VectorStorage where
+    _Empty = nearly defaultVectorStorage vectorStorageNull

--- a/src/Polar/Types/Storage.hs
+++ b/src/Polar/Types/Storage.hs
@@ -17,21 +17,21 @@ import Data.Dynamic
 import qualified Data.Vector as V
 import qualified Data.HashMap.Lazy as M
 
-data InnerStorage = InnerStorage
-    { _innerStorageDyns  :: V.Vector Dynamic
-    , _innerStorageNames :: M.HashMap String Int
+data VectorStorage = VectorStorage
+    { _vectorStorageDyns  :: V.Vector Dynamic
+    , _vectorStorageNames :: M.HashMap String Int
     }
 
-defaultInnerStorage :: InnerStorage
-defaultInnerStorage = InnerStorage
-    { _innerStorageDyns  = V.empty
-    , _innerStorageNames = M.empty
+defaultVectorStorage :: VectorStorage
+defaultVectorStorage = VectorStorage
+    { _vectorStorageDyns  = V.empty
+    , _vectorStorageNames = M.empty
     }
 
-innerStorageNull :: InnerStorage -> Bool
-innerStorageNull s = V.null (_innerStorageDyns s)
+vectorStorageNull :: VectorStorage -> Bool
+vectorStorageNull s = V.null (_vectorStorageDyns s)
 
-type Storage = M.HashMap TypeRep InnerStorage
+type Storage = M.HashMap TypeRep VectorStorage
 
 defaultStorage :: Storage
 defaultStorage = M.empty

--- a/src/Polar/Types/Storage.hs
+++ b/src/Polar/Types/Storage.hs
@@ -16,15 +16,20 @@ import Data.Typeable
 import Data.Dynamic
 import qualified Data.Vector as V
 import qualified Data.HashMap.Lazy as M
-import Control.Lens (Lens, Field1, Field2, _1, _2)
 
-type InnerStorage = (V.Vector Dynamic, M.HashMap String Int)
+data InnerStorage = InnerStorage
+    { _innerStorageDyns  :: V.Vector Dynamic
+    , _innerStorageNames :: M.HashMap String Int
+    }
 
-innerDyns :: Field1 s t a b => Lens s t a b
-innerDyns = _1
+defaultInnerStorage :: InnerStorage
+defaultInnerStorage = InnerStorage
+    { _innerStorageDyns  = V.empty
+    , _innerStorageNames = M.empty
+    }
 
-innerNames :: Field2 s t a b => Lens s t a b
-innerNames = _2
+innerStorageNull :: InnerStorage -> Bool
+innerStorageNull s = V.null (_innerStorageDyns s)
 
 type Storage = M.HashMap TypeRep InnerStorage
 

--- a/src/Polar/Types/Storage.hs
+++ b/src/Polar/Types/Storage.hs
@@ -17,21 +17,24 @@ import Data.Dynamic
 import qualified Data.Vector as V
 import qualified Data.HashMap.Lazy as M
 
+type Storage = M.HashMap TypeRep VectorStorage
+
 data VectorStorage = VectorStorage
-    { _vectorStorageDyns  :: V.Vector Dynamic
-    , _vectorStorageNames :: M.HashMap String Int
+    { _vectorStorageDyns :: V.Vector Dynamic
+    , _vectorStorageKeys :: M.HashMap TypeRep KeyStorage
     }
+
+-- key hash => index
+type KeyStorage = M.HashMap Int Int
+
+defaultStorage :: Storage
+defaultStorage = M.empty
 
 defaultVectorStorage :: VectorStorage
 defaultVectorStorage = VectorStorage
-    { _vectorStorageDyns  = V.empty
-    , _vectorStorageNames = M.empty
+    { _vectorStorageDyns = V.empty
+    , _vectorStorageKeys = M.empty
     }
 
 vectorStorageNull :: VectorStorage -> Bool
 vectorStorageNull s = V.null (_vectorStorageDyns s)
-
-type Storage = M.HashMap TypeRep VectorStorage
-
-defaultStorage :: Storage
-defaultStorage = M.empty


### PR DESCRIPTION
This patch replaces the name=>index HashMap for vector storages with a HashMap from hash=>index nested within another HashMap by TypeRep.

Essentially this allows arbitrary values to be added as a lookup key for any index in a vector storage as long as that key is Hashable. This increases the number of lookups and insertions by 1 but all lookups and insertions still take place in amortized constant time!
