### PR TITLE
Support building with stack

### DIFF
--- a/polar-engine.cabal
+++ b/polar-engine.cabal
@@ -40,7 +40,6 @@ library
   build-depends:       base >=4.8 && <5.0, containers >=0.5.5, transformers >=0.4, mtl >=2.2, bytestring >=0.10, lens >=4.12,
                        hint >=0.4, unordered-containers >=0.2, vector >=0.11, hashable >=1.2, stm >=2.4,
                        OpenGL >=2.12, OpenGLRaw >2.1, GLFW-b >=1.4.7,
-                       tight-apply >=0.1 && <0.2, truthful >=0.1 && <0.2,
                        polar-shader >=0.1 && <0.2, polar-configfile >=0.5
   default-language:    Haskell2010
   hs-source-dirs:      src

--- a/src/Polar/System/Renderer/OpenGL_3_2.hs
+++ b/src/Polar/System/Renderer/OpenGL_3_2.hs
@@ -18,7 +18,7 @@ import Data.Foldable (traverse_)
 import Data.Hashable (Hashable)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Map as M
-import Control.Monad.RWS (MonadIO, void, when, liftIO, tell)
+import Control.Monad.RWS (MonadIO, void, liftIO, tell)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TChan
 import Foreign (nullPtr, sizeOf, withArray)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- polar-configfile-0.5.0.0
+- polar-shader-0.1.0.4
+resolver: lts-6.12


### PR DESCRIPTION
This PR includes a minor commit removing an unnecessary import of `when`, as well as a major commit removing the unused dependencies `truthful` and `tight-apply` and adding a very basic stack file.
