### PR TITLE
Submit real primitives over renderer message queue

### DIFF
--- a/examples/basic/Main.hs
+++ b/examples/basic/Main.hs
@@ -10,10 +10,16 @@ hello = defaultSystem "Hello"
     & startup  .~ logWrite NOTICE "Hello!"
     & shutdown .~ logWrite NOTICE "Goodbye... :("
 
-prim :: System
-prim = defaultSystem "Primitive Submitter"
-    & startup .~ tell [SysCoreAction (void $ submitPrimitive ())]
+primSubmitter :: System
+primSubmitter = defaultSystem "Primitive Submitter"
+    & startup .~ tell [SysCoreAction (void $ submitPrimitive prim)]
+
+prim :: Primitive
+prim = [ -1, -1
+       ,  1, -1
+       ,  0,  1
+       ]
 
 main :: IO ()
 main = run $ defaultEngine
-    & systems .~ [hello, prim, renderer]
+    & systems .~ [hello, primSubmitter, renderer]

--- a/polar-engine.cabal
+++ b/polar-engine.cabal
@@ -38,6 +38,7 @@ library
                        Polar.Types.Config,
                        Polar.Types.Log,
                        Polar.Types.Storage,
+                       Polar.Types.Primitive,
                        Polar.Types.Lenses
   build-depends:       base >=4.8 && <5.0, containers >=0.5.5, transformers >=0.4, mtl >=2.2, bytestring >=0.10, lens >=4.12,
                        hint >=0.4, unordered-containers >=0.2, vector >=0.11, hashable >=1.2, stm >=2.4,

--- a/src/Polar/System/Renderer.hs
+++ b/src/Polar/System/Renderer.hs
@@ -21,13 +21,14 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TChan
 import GHC.Generics
+import Polar.Types
 import Polar.Storage
 import Polar.Unique
 
 data RendererKey = RendererKey deriving Generic
 instance Hashable RendererKey
 
-submitPrimitive :: (MonadIO m, StorePolar m) => () -> m Integer
+submitPrimitive :: (MonadIO m, StorePolar m) => Primitive -> m Integer
 submitPrimitive x = do
     uid <- unique
     chan <- mRetrieveKeyed RendererKey >>= \case
@@ -39,7 +40,7 @@ submitPrimitive x = do
     liftIO $ atomically (writeTChan chan (uid, x))
     pure uid
 
-readRendererMsg :: (MonadIO m, StorePolar m) => m (Maybe (Integer, ()))
+readRendererMsg :: (MonadIO m, StorePolar m) => m (Maybe (Integer, Primitive))
 readRendererMsg = do
     mRetrieveKeyed RendererKey >>= \case
         Nothing   -> pure Nothing

--- a/src/Polar/Types.hs
+++ b/src/Polar/Types.hs
@@ -23,6 +23,7 @@ module Polar.Types
 , module Polar.Types.Config
 , module Polar.Types.Log
 , module Polar.Types.Storage
+, module Polar.Types.Primitive
 , module Polar.Types.Lenses
 ) where
 
@@ -39,4 +40,5 @@ import Polar.Types.Engine
 import Polar.Types.Config
 import Polar.Types.Log
 import Polar.Types.Storage
+import Polar.Types.Primitive
 import Polar.Types.Lenses

--- a/src/Polar/Types/Primitive.hs
+++ b/src/Polar/Types/Primitive.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Safe #-}
+
+{-|
+  Module      : Polar.Types.Primitive
+  Copyright   : (c) 2016 David Farrell
+  License     : Apache-2.0
+  Stability   : unstable
+  Portability : portable
+
+  Renderer types.
+-}
+
+module Polar.Types.Primitive (Primitive) where
+
+import Foreign.C.Types (CFloat)
+
+type Primitive = [CFloat]


### PR DESCRIPTION
This patch  removes the hardcoded triangle primitive from the OpenGL
renderer and instead submits it via the updated message queue from
example-basic.

Addresses #13 partially.
